### PR TITLE
Update Node.js version in Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
previous UI builder crashes due to node version. Testing whether it will work with Node22.

Relevant logs:
```
[09:18:27] → #24 [ui builder 4/6] RUN npm ci
[09:18:30] → #24 6.347 npm warn EBADENGINE Unsupported engine {
#24 6.347 npm warn EBADENGINE   package: 'starknet@9.2.1',
#24 6.347 npm warn EBADENGINE   required: { node: '>=22' },
#24 6.347 npm warn EBADENGINE   current: { node: 'v20.20.0', npm: '10.8.2' }
```